### PR TITLE
Remove need for creating derived pangeo image

### DIFF
--- a/examples/simple/hub_image/jupyterhub_config.py
+++ b/examples/simple/hub_image/jupyterhub_config.py
@@ -19,3 +19,7 @@ c.DockerSpawner.network_name = 'jupyterhub'
 
 # delete containers when the stop
 c.DockerSpawner.remove = True
+
+# explicitly set cmd, so we start jupyterhub-singleuser rather than jupyter notebook
+# This is useful when running docker images that aren't built specifically for JupyterHub
+c.DockerSpawner.cmd = 'jupyterhub-singleuser'


### PR DESCRIPTION
Since DockerSpawner defaults to using the `CMD` defined in the docker image,
`jupyter notebook` is started for the PANGEO images - rather than 
`jupyterhub-singleuser`. Instead of manually creating images, we can set
this property explicitly instead. This should allow use of any PANGEO image.